### PR TITLE
Make iterator immutable to fix warning

### DIFF
--- a/iterator/src/main.rs
+++ b/iterator/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     println!();
 
     // Creating an iterator
-    let mut iterator = numbers.iter();
+    let iterator = numbers.iter();
 
     // Looping over elements using the iterator
     println!("Looping over elements using an iterator:");


### PR DESCRIPTION
Running the iterator program outputs a warning about unused mutability of the iterator. Fixed this in the PR.